### PR TITLE
Allow the tag to be specified separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ version number is tracked in the file `VERSION`.
 
 ## [Unreleased]
 ### Changed
-- Fix after_deploy.sh so that the current directory is mounted in when calling announce
+- Fix `after_deploy.sh` so that the current directory is mounted in when calling announce
 
 ### Added
+- Allow the tag to be specified separately to the changelog version
 
 ## [2.2.0] - 2019-07-16
 ### Changed

--- a/announcer/__init__.py
+++ b/announcer/__init__.py
@@ -28,6 +28,7 @@ def announce(
     username: str = None,
     icon_url: str = None,
     icon_emoji: str = None,
+    tag: str = None,
 ):
     """Main script for announce
 
@@ -71,7 +72,8 @@ def announce(
 
     if base_url:
         # Add a button to view the CHANGELOG.md.
-        changelog_url = "{0}/blob/{1}/CHANGELOG.md".format(base_url, changelogversion)
+        tag = tag if tag else changelogversion
+        changelog_url = "{0}/blob/{1}/CHANGELOG.md".format(base_url, tag)
         fallback.append("View CHANGELOG.md at {0}".format(changelog_url))
         actions.append(
             {"type": "button", "text": "View CHANGELOG.md", "url": changelog_url}
@@ -174,6 +176,11 @@ def main():
         help="A Slack emoji code to use for the user icon in the announcement "
         "(e.g. party_parrot)",
     )
+    parser.add_argument(
+        "--tag",
+        dest="tag",
+        help="The tag to announce (e.g. 1.0.0). Defaults to changelogversion",
+    )
 
     args = parser.parse_args()
 
@@ -186,6 +193,7 @@ def main():
             username=args.username,
             icon_url=args.iconurl,
             icon_emoji=args.iconemoji,
+            tag=args.tag,
         )
     except Exception as e:
         log.exception(e)


### PR DESCRIPTION
Max,

This allows the tag to be specified, separately from the changelog version.

This allows announcer to be used on repositories which use a tag that's different to the headings in the changelog file.